### PR TITLE
feat: support routePrefix in pluginLoader

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -13,6 +13,7 @@ export async function build() {
 
   app.register(pluginLoader, {
     dir: path.join(import.meta.dirname, 'routes'),
+    routePrefix: '/api/v1',
   })
 
   return app

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ try {
   await app.listen({
     host: '0.0.0.0',
     port: 5000,
-    listenTextResolver: (address) => `Webhook Playground listening on ${address}/api/docs`,
+    listenTextResolver: (address) => `Webhook Playground listening on ${address}/api/v1/docs`,
   })
 } catch (error) {
   app.log.error(error)

--- a/src/plugins/external/swagger.ts
+++ b/src/plugins/external/swagger.ts
@@ -2,6 +2,8 @@ import fastifySwagger from '@fastify/swagger'
 import fp from 'fastify-plugin'
 
 export default fp(async function (fastify) {
+  const docV1Url = '/api/v1/docs'
+
   /**
    * A Fastify plugin for serving Swagger (OpenAPI v2) or OpenAPI v3 schemas
    *
@@ -17,18 +19,21 @@ export default fp(async function (fastify) {
     },
   })
 
-  fastify.register(async function (fastify) {
-    fastify.get('/api/docs', { schema: { hide: true } }, (_request, reply) => {
-      reply.type('text/html').send(apiReferenceHtml)
-    })
+  fastify.register(
+    async function (fastify) {
+      fastify.get('/', (_request, reply) => {
+        reply.type('text/html').send(apiReferenceHtml(`${docV1Url}/json`))
+      })
 
-    fastify.get('/api/docs/json', { schema: { hide: true } }, (_request, reply) => {
-      reply.send(fastify.swagger())
-    })
-  })
+      fastify.get('/json', (_request, reply) => {
+        reply.send(fastify.swagger())
+      })
+    },
+    { prefix: docV1Url, preset: { schema: { hide: true } } },
+  )
 })
 
-const apiReferenceHtml = `
+const apiReferenceHtml = (url: string) => `
 <!DOCTYPE html>
 <html>
   <head>
@@ -47,7 +52,7 @@ const apiReferenceHtml = `
     <script>
       Scalar.createApiReference("#app", {
         // The URL of the OpenAPI/Swagger document
-        url: "/api/docs/json",
+        url: "${url}",
         // Avoid CORS issues
         proxyUrl: "https://proxy.scalar.com",
       });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - All API routes are now versioned under the `/api/v1` prefix.
  - API documentation and Swagger JSON are now available at `/api/v1/docs` and `/api/v1/docs/json`.

- **Refactor**
  - Updated the API documentation endpoint to use a dynamic URL and consolidated the Swagger UI and JSON endpoints under a single versioned prefix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->